### PR TITLE
Add Turntable

### DIFF
--- a/Clients.md
+++ b/Clients.md
@@ -60,4 +60,5 @@ For each client, we'd like to know:
 | [[RhythmBox]]             | rbx         |                                         | No                 |            |
 | [[Simple Scrobbler]]      | sls         | N/A                                     | Yes                | No         |
 | [[Strawberry]]            | N/A         | N/A                                     | No                 | No         |
+| [[Turntable]]             | N/A         | @GeopJr                                 | No                 | No         |
 | [[Web Scrobbler]]         | N/A         |                                         | No                 | No         |

--- a/Turntable.md
+++ b/Turntable.md
@@ -1,0 +1,12 @@
+Turntable is an MPRIS enabled music widget and scrobbler for Linux.
+
+It supports all MPRIS-enabled music players and can scrobble to Libre.fm, ListenBrainz, last.fm and Maloja.
+
+It also comes with a CLI for those only interested in scrobbling.
+
+* https://turntable.geopjr.dev/
+
+### Who's using it?
+
+* GeopJr
+* Add your username/URL here


### PR DESCRIPTION
[Website](https://turntable.geopjr.dev/) | [Flathub](https://flathub.org/apps/dev.geopjr.Turntable) | [Source](https://codeberg.org/GeopJr/Turntable)

Turntable is an MPRIS widget and scrobbler for Linux. It can scrobble to Libre.fm, ListenBrainz, last.fm and Maloja. It also comes with a CLI.
