### PR TITLE
Add fooyin

### DIFF
--- a/Clients.md
+++ b/Clients.md
@@ -60,6 +60,7 @@ For each client, we'd like to know:
 | [[Cuberok]]               | cub         | N/A                                     | Yes                | No         |
 | [[DeaDBeeF]]              | ddb         | N/A                                     | Yes                | No         |
 | [[Foobar2000]]            | foo         | N/A                                     | Yes                | No         |
+| [[fooyin]]                | N/A         | @ludouzi                                | No                 | No         |
 | [[Last.fm player]]        | ass         | N/A                                     | Yes                | No         |
 | [[mpdscribble]]           | mdc         |                                         | Yes                | No         |
 | [[mpris-scrobbler]]       | N/A         | @mariusor                               | Yes                | No         |

--- a/fooyin.md
+++ b/fooyin.md
@@ -1,0 +1,8 @@
+fooyin is a customisable desktop music player. It plays major audio formats and supports playlists, metadata tools, plugins, scripting, and scrobbling.
+
+* [Website](https://fooyin.org)
+
+### Who's using it?
+
+* [ludouzi](https://github.com/ludouzi)
+* Add your username/URL here


### PR DESCRIPTION
fooyin is a customisable desktop music player for Linux, with support for Windows and macOS coming soon. It supports scrobbling to Libre.fm, Last.fm, ListenBrainz, and other custom services.